### PR TITLE
Add yarn start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wizeline Design System
 ## Steps to verify successful styleguide setup
 
 1. `yarn install`
-2. `npm run styleguide`
+2. `yarn start`
 3. `Open localhost:6060 in your favourite browser`
 
 ## Running the tests

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint-staged": "lint-staged",
     "lint": "eslint ./",
     "precommit": "lint-staged",
+    "start": "styleguidist server",
     "styleguide:build": "styleguidist build",
     "styleguide": "styleguidist server",
     "test-debug": "jest --coverage --debug",


### PR DESCRIPTION
## Reason for changes

Got tired of typing out `npm run styleguide` now we can type `yarn start`. 

## Screenshots

### Look at it run
![screen shot 2018-01-24 at 12 14 09 pm](https://user-images.githubusercontent.com/10840350/35349404-7150795c-0100-11e8-9f25-12882f3a4032.png)

### `localhost:6060` up and running
![screen shot 2018-01-24 at 12 14 27 pm](https://user-images.githubusercontent.com/10840350/35349405-716a15ba-0100-11e8-91fe-6309e8b1eaa2.png)

### Updated documentation
![screen shot 2018-01-24 at 12 18 16 pm](https://user-images.githubusercontent.com/10840350/35349506-bc00e932-0100-11e8-9a1c-b9d69ad3aac1.png)
