### PR TITLE
Fixed focus style for inputs with error and complete checkbox example

### DIFF
--- a/design-system/src/components/input/input.scss
+++ b/design-system/src/components/input/input.scss
@@ -1,6 +1,9 @@
 wz-input {
   .error .input-container {
     border-color: var(--negative-base);
+    &:focus-within {
+      border-color: var(--negative-base);
+    }
   }
 
   wz-error {

--- a/site/pages/checkbox.md
+++ b/site/pages/checkbox.md
@@ -15,5 +15,5 @@ showSource: true
 ---
 <wz-checkbox disabled>Regular</wz-checkbox>
 <wz-checkbox disabled>Veggie</wz-checkbox>
-<wz-checkbox checked>Vegan</wz-checkbox>
+<wz-checkbox disabled checked>Vegan</wz-checkbox>
 ```


### PR DESCRIPTION
## Description
Minor fixes

- Fix focus error style:
**Error:** Fields with error changed border color on focus 
![image](https://user-images.githubusercontent.com/2468428/49667522-332fee00-fa10-11e8-8b1d-ea2be9f4c09d.png)
**Expected:** Fields with error should not change color on focus
![image](https://user-images.githubusercontent.com/2468428/49668542-632cc080-fa13-11e8-99b7-4faa638eee94.png)

- Missing prop on checkbox example
**Error:** Disabled example without disabled prop
![image](https://user-images.githubusercontent.com/2468428/49668706-d20a1980-fa13-11e8-9057-5b20ca8cdd32.png)
**Expected:** Disabled example with disabled prop
![image](https://user-images.githubusercontent.com/2468428/49668689-c4549400-fa13-11e8-8fd9-0db2a863021b.png)

