### PR TITLE
Fix for multiple toggle components

### DIFF
--- a/design-system/src/components/toggle/toggle.scss
+++ b/design-system/src/components/toggle/toggle.scss
@@ -6,12 +6,7 @@ wz-toggle {
     var(--switchWidth) - var(--innerCircleSize) - var(--padding)
   );
 
-  input[type='checkbox'] {
-    display: none;
-  }
-
-  label {
-    content: '';
+  input {
     display: flex;
     align-items: center;
     position: relative;
@@ -20,31 +15,33 @@ wz-toggle {
     border-radius: 14px;
     background-color: var(--secondary-dark);
     cursor: pointer;
-  }
+    appearance: none;
+    outline: none;
 
-  label:before {
-    position: absolute;
-    content: '';
-    width: var(--innerCircleSize);
-    height: var(--innerCircleSize);
-    border-radius: 50%;
-    background-color: var(--surface-base);
-    @include transition(transform);
-    transform: translateX(var(--padding));
-  }
-
-  input[type='checkbox']:checked + label {
-    background-color: var(--primary-base);
-    @include transition(background-color);
     &:before {
-      transform: translateX(var(--checkedPosition));
+      position: absolute;
+      content: '';
+      width: var(--innerCircleSize);
+      height: var(--innerCircleSize);
+      border-radius: 50%;
+      background-color: var(--surface-base);
+      @include transition(transform);
+      transform: translateX(var(--padding));
     }
-  }
 
-  input[type='checkbox']:disabled + label {
-    background-color: var(--secondary-dark);
-    &:before {
-      background-color: var(--ink-light);
+    &:checked {
+      background-color: var(--primary-base);
+      @include transition(background-color);
+      &:before {
+        transform: translateX(var(--checkedPosition));
+      }
+    }
+
+    &:disabled {
+      background-color: var(--secondary-dark);
+      &:before {
+        background-color: var(--ink-light);
+      }
     }
   }
 }

--- a/design-system/src/components/toggle/toggle.tsx
+++ b/design-system/src/components/toggle/toggle.tsx
@@ -22,7 +22,6 @@ export class Toggle {
           id={this.id}
           type="checkbox"
         />
-        <label htmlFor={this.id} />
       </div>
     );
   }


### PR DESCRIPTION
## Description

Multiple toggle components won't work.

The reason is that the way <label> `for` attribute is used:
- An `id` is provided as property to the `wz-toggle` component.
- This `id` is used for the inner `input` as an `id` attribute and for the label as the `for` attribute.
- This caused a conflict for the <label> since the tag doesn't support multiple ids, blocking the toggle functionality.

![image 1](https://user-images.githubusercontent.com/2468428/53607392-77481000-3b73-11e9-97bb-ee50ce35b28a.png)


### How is this working in some places?:
- If you don't give any `id` to the component and it is the only one you won't have any conflict therefor it will work.

### The fix:
Forget about the label and go straight into styling the checkbox maintaining its toggle functionality and already defined styles.

Example & code:
![feb-28-2019 15-51-33](https://user-images.githubusercontent.com/2468428/53607408-88911c80-3b73-11e9-9540-213afbe4dd4e.gif)
```
  <wz-toggle id="uno" oninput="console.log('--1-')"></wz-toggle>
  <wz-toggle id="dos" disabled oninput="console.log('--2-')"></wz-toggle>
  <wz-toggle checked id="tres" oninput="console.log('--3-')"/></wz-toggle>
  <wz-toggle checked id="cuatro" disabled oninput="console.log('--4-')"/></wz-toggle>
```