### PR TITLE
Update colors

### DIFF
--- a/design-system/src/css/colors/colors.scss
+++ b/design-system/src/css/colors/colors.scss
@@ -5,7 +5,7 @@
   --info-base: #4765AA;
   --info-dark: #3E5693;
 
-  --ink-clear: #F0F0F0; // Not final
+  --ink-clear: #F0F0F0;
   --ink-light: #717171;
   --ink-base: #262626;
   --ink-dark: #182123;
@@ -26,9 +26,9 @@
   --primary-base: #0A76DB;
   --primary-dark: #0966bE;
 
-  --secondary-light: #E6E7E8; // Not final
-  --secondary-base: #FFF; // Not final
-  --secondary-dark: #E6E7E8; // Not final
+  --secondary-light: #FFF;
+  --secondary-base: #FFF;
+  --secondary-dark: #E6E7E8;
 
   --surface-base: #FFF;
 

--- a/site/pages/colors.md
+++ b/site/pages/colors.md
@@ -9,7 +9,7 @@ colors:
 
 ```color-palette
 colors:
- - { name: "var(--secondary-light)", value: "#E6E7E8" }
+ - { name: "var(--secondary-light)", value: "#FFF" }
  - { name: "var(--secondary-base)", value: "#FFF" }
  - { name: "var(--secondary-dark)", value: "#E6E7E8" }
 ```


### PR DESCRIPTION
Based on zeplin definitions https://zpl.io/ad7G3KK

@jugerardo & @jfer-rubio  agreed to assign the #FFF to secondary-light
![image](https://user-images.githubusercontent.com/2468428/55180999-f2d3b780-5147-11e9-9e8e-af9f659618db.png)
